### PR TITLE
Add missing test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,19 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <version>2.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <version>2.8.2</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
This apparently broke recently since we changed gwt-event-dom to not include gwt-user.

I'm not clear why gwt-dev itself is needed here (since gwt-event-dom didnt have it?), but locally I needed it to get the build to pass.